### PR TITLE
Adds toString to make it easier for hashcodes check, add documentation links

### DIFF
--- a/equalsverifier/README.adoc
+++ b/equalsverifier/README.adoc
@@ -6,6 +6,8 @@ Add dependency to pom.xml and use it in tests to verify whether equals and hashc
 
 You can run example project with `mvn clean package` that demos the intended functionality.
 
+More documentation can be found https://github.com/jqno/equalsverifier[in Github] and https://jqno.nl/equalsverifier/[on their website].
+
 === Add the following to pom.xml
 
 .pom.xml

--- a/equalsverifier/src/main/java/com/teragrep/ev/BadImplementation.java
+++ b/equalsverifier/src/main/java/com/teragrep/ev/BadImplementation.java
@@ -10,6 +10,11 @@ public class BadImplementation implements ExampleInterface {
     }
 
     @Override
+    public String toString() {
+        return "Hello, " + name + ", I am " + age + " years old.";
+    }
+
+    @Override
     public final boolean equals(Object o) {
         if (o == this) {
             return true;

--- a/equalsverifier/src/main/java/com/teragrep/ev/GoodImplementation.java
+++ b/equalsverifier/src/main/java/com/teragrep/ev/GoodImplementation.java
@@ -10,6 +10,11 @@ public class GoodImplementation implements ExampleInterface {
     }
 
     @Override
+    public String toString() {
+        return "Hello, " + name + ", I am " + age + " years old.";
+    }
+
+    @Override
     public final int hashCode() {
         int result = 17;
         if(name != null) {


### PR DESCRIPTION
Changes

```
java.lang.AssertionError: 
EqualsVerifier found a problem in class com.teragrep.ev.BadImplementation.
-> hashCode: hashCodes should be equal:
  com.teragrep.ev.BadImplementation@294a6b8e (692743054)
and
  com.teragrep.ev.BadImplementation@4b1d6571 (1260217713)
```

to

```
java.lang.AssertionError: 
EqualsVerifier found a problem in class com.teragrep.ev.BadImplementation.
-> hashCode: hashCodes should be equal:
  Hello, one, I am 1 years old. (692743054)
and
  Hello, one, I am 1 years old. (1260217713)
```

in example as it uses toString()

Also add documentation links for more info