### PR TITLE
Remove package from ci.yaml as that causes issues when duplicate life…

### DIFF
--- a/workflows/ci.yaml
+++ b/workflows/ci.yaml
@@ -23,4 +23,4 @@ jobs:
           distribution: 'adopt'
 
       - name: Run CI
-        run: mvn --batch-mode clean verify package
+        run: mvn --batch-mode clean verify


### PR DESCRIPTION
…cycles trigger

From [Lifecycles documentation](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html)

```
This command executes each default lifecycle phase in order (validate, compile, package, etc.), before executing verify.
```

Duplicate lifecycle causes issues such as

```
[INFO] 
[INFO] --- source:3.3.0:jar-no-fork (attach-sources) @ pth_10 ---
[INFO] Building jar: /home/runner/work/pth_10/pth_10/target/pth_10-sources.jar
Error:  We have duplicated artifacts attached.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  18:18 min
[INFO] Finished at: 2025-02-04T17:11:32Z
[INFO] ------------------------------------------------------------------------
Error:  Failed to execute goal org.apache.maven.plugins:maven-source-plugin:3.3.0:jar-no-fork (attach-sources) on project pth_10: Presumably you have configured maven-source-plugn to execute twice times in your build. You have to configure a classifier for at least on of them. -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
Error: Process completed with exit code 1.
```